### PR TITLE
Harden cURL call and prevent doubled package install

### DIFF
--- a/install
+++ b/install
@@ -1,14 +1,14 @@
 #!/bin/bash
 
 RI=raspi-info
-UPVER=$(curl -sSL https://raw.githubusercontent.com/mapi68/$RI/master/version)
+UPVER=$(curl -sSfL https://raw.githubusercontent.com/mapi68/$RI/master/version)
 VERSION=$(dpkg -s $RI | grep '^Version:' | awk '/:/ {print $2}')
 
 install() {
 	if [[ `uname -m` = aarch64 ]]; then
 		wget -P /tmp/ https://github.com/mapi68/"$RI"/raw/master/"$RI"_latest-64.deb; else
 		wget -P /tmp/ https://github.com/mapi68/"$RI"/raw/master/"$RI"_latest-32.deb; fi
-	sudo dpkg -i /tmp/"$RI"_latest-*.deb; sudo apt install -f -y; rm /tmp/"$RI"_latest-*
+	sudo apt install -y /tmp/"$RI"_latest-*.deb; rm /tmp/"$RI"_latest-*
 }
 
 if ! [ -f /usr/bin/$RI ]; then

--- a/raspi-info-update
+++ b/raspi-info-update
@@ -1,14 +1,14 @@
 #!/bin/bash
 
 RI=raspi-info
-UPVER=$(curl -sSL https://raw.githubusercontent.com/mapi68/$RI/master/version)
+UPVER=$(curl -sSfL https://raw.githubusercontent.com/mapi68/$RI/master/version)
 VERSION=$(dpkg -s $RI | grep '^Version:' | awk '/:/ {print $2}')
 
 install() {
 	if [[ `uname -m` = aarch64 ]]; then
 		wget -P /tmp/ https://github.com/mapi68/"$RI"/raw/master/"$RI"_latest-64.deb; else
 		wget -P /tmp/ https://github.com/mapi68/"$RI"/raw/master/"$RI"_latest-32.deb; fi
-	sudo dpkg -i /tmp/"$RI"_latest-*.deb; sudo apt install -f -y; rm /tmp/"$RI"_latest-*
+	sudo apt install -y /tmp/"$RI"_latest-*.deb; rm /tmp/"$RI"_latest-*
 }
 
 if [[ "$VERSION" -ge "$UPVER" ]]; then


### PR DESCRIPTION
In some cases, the webserver responds with an actual HTML 404 error page instead of a raw (empty) 404 response. cURL then outputs the 404 HTML to STDOUT instead of the expected document, which may be huge or even match further processing within the calling script. It is hence good practice to use the `-f` option, to make cURL fail as well in case of a 404 HTML error page, printing a shortened error message to STDERR and leaving STDOUT empty.

`apt` and `apt-get` can be used to install package files directly, using the file path(s) as argument. The `dpkg -i` + `apt install -f` workaround to automatically install dependencies is hence not required and the irritating error output and additional processing can be prevented.